### PR TITLE
add support for i18n ugettext_lazy strings

### DIFF
--- a/jsonfield/tests/test_fields.py
+++ b/jsonfield/tests/test_fields.py
@@ -1,4 +1,5 @@
 #:coding=utf-8:
+from django.utils.translation import ugettext_lazy as _
 from django.test import TestCase as DjangoTestCase
 from django.utils.encoding import force_text
 from django import forms
@@ -100,6 +101,16 @@ class JSONFieldTest(DjangoTestCase):
         self.assertEqual(2, JSONFieldTestModel.objects.filter(json__contains='foo').count())
         # This code needs to be implemented!
         self.assertRaises(TypeError, lambda: JSONFieldTestModel.objects.filter(json__contains=['baz', 'foo']))
+
+    def test_i18n_lazy_object(self):
+        """
+        Test jsonfield can work with ugettext_lazy objects
+        """
+        # Create i18n object with ugettext_lazy value
+        i18n_obj = JSONFieldTestModel.objects.create(json={'foo': _('bar')})
+        # Check it was saved and its equal to bar
+        self.assertEqual(JSONFieldTestModel.objects.get(id=i18n_obj.id).json['foo'],
+                         'bar')
 
     def test_query_isnull(self):
         JSONFieldTestModel.objects.create(json=None)

--- a/jsonfield/utils.py
+++ b/jsonfield/utils.py
@@ -1,6 +1,8 @@
 import datetime
 from decimal import Decimal
 
+from django.utils.functional import Promise
+from django.utils.encoding import force_text
 from django.core.serializers.json import DjangoJSONEncoder
 
 
@@ -12,6 +14,8 @@ class TZAwareJSONEncoder(DjangoJSONEncoder):
 
 
 def default(o):
+    if isinstance(o, Promise):
+        return force_text(o)
     if hasattr(o, 'to_json'):
         return o.to_json()
     if isinstance(o, Decimal):


### PR DESCRIPTION
Support for "from django.utils.translation import ugettext_lazy", when i tried to save ugettext_lazy string i catched an error: 'TypeError: <django.utils.functional.__proxy__ object at 0x89e0b90> is not JSON serializable' so i decide to fix it. Fix inspired by LazyEncoder from https://docs.djangoproject.com/en/1.9/topics/serialization/
